### PR TITLE
feat: add spanish code detection

### DIFF
--- a/app/src/main/java/io/github/jd1378/otphelper/utils/CodeExtractor.kt
+++ b/app/src/main/java/io/github/jd1378/otphelper/utils/CodeExtractor.kt
@@ -2,7 +2,7 @@ package io.github.jd1378.otphelper.utils
 
 class CodeExtractor {
   companion object {
-    private val sensitiveWords = listOf("code", "کد", "رمز", "\\bOTP\\b", "Einmalkennwort")
+    private val sensitiveWords = listOf("code", "کد", "رمز", "\\bOTP\\b", "Einmalkennwort", "contraseña", "c[oó]digo", "clave")
     private val ignoredWords = listOf("مقدار", "مبلغ", "amount", "برای", "-ارز")
     private val generalCodeMatcher =
         """(?:${sensitiveWords.joinToString("|")})(?:\s*(?!${

--- a/app/src/test/java/io/github/jd1378/otphelper/CodeDetectionUnitTest.kt
+++ b/app/src/test/java/io/github/jd1378/otphelper/CodeDetectionUnitTest.kt
@@ -161,21 +161,43 @@ www.iranketab.ir
   }
 
   @Test
-  fun spanishCode() {
-      val testCases = listOf(
-          Pair("Su codigo de verificacion de AAAA es 123456", "123456"),
-          Pair("123456 es el código de verificación para tu cuenta de Sony.", "123456"),
-          Pair("BBB. Clave de firma: 1234. Introduce esta clave de un solo uso (OTP) en el formulario web para firmar (SMS CERTIFICADO)", "1234"),
-          Pair("123 456 es tu código de Instagram. No lo compartas.", "123456"),
-          Pair("PayPal: Tu código de seguridad es 123456. No lo compartas con nadie.", "123456"),
-          Pair("Se ha generado el siguiente codigo de un solo uso: 12345678", "12345678"),
-          Pair("123456 es tu contraseña temporal de Amazon. No la compartas con nadie.", "123456")
-      )
+  fun spanishCode1() {
+      val msg = "Su codigo de verificacion de AAAA es 123456"
+      val expectedCode = "123456"
+      assertEquals(false, CodeIgnore.shouldIgnore(msg))
+      assertEquals(expectedCode, CodeExtractor.getCode(msg))
+  }
 
-      for ((msg, expectedCode) in testCases) {
-          assertEquals(false, CodeIgnore.shouldIgnore(msg))
-          assertEquals(expectedCode, CodeExtractor.getCode(msg))
-      }
+  @Test
+  fun spanishCode2() {
+      val msg = "BBB. Clave de firma: 1234. Introduce esta clave de un solo uso (OTP) en el formulario web para firmar (SMS CERTIFICADO)"
+      val expectedCode = "1234"
+      assertEquals(false, CodeIgnore.shouldIgnore(msg))
+      assertEquals(expectedCode, CodeExtractor.getCode(msg))
+  }
+
+  @Test
+  fun spanishCode3() {
+      val msg = "123 456 es tu código de Instagram. No lo compartas."
+      val expectedCode = "123456"
+      assertEquals(false, CodeIgnore.shouldIgnore(msg))
+      assertEquals(expectedCode, CodeExtractor.getCode(msg))
+  }
+
+  @Test
+  fun spanishCode4() {
+      val msg = "PayPal: Tu código de seguridad es 123456. No lo compartas con nadie."
+      val expectedCode = "123456"
+      assertEquals(false, CodeIgnore.shouldIgnore(msg))
+      assertEquals(expectedCode, CodeExtractor.getCode(msg))
+  }
+
+  @Test
+  fun spanishCode5() {
+      val msg = "123456 es tu contraseña temporal de Amazon. No la compartas con nadie."
+      val expectedCode = "123456"
+      assertEquals(false, CodeIgnore.shouldIgnore(msg))
+      assertEquals(expectedCode, CodeExtractor.getCode(msg))
   }
 
   @Test

--- a/app/src/test/java/io/github/jd1378/otphelper/CodeDetectionUnitTest.kt
+++ b/app/src/test/java/io/github/jd1378/otphelper/CodeDetectionUnitTest.kt
@@ -161,6 +161,24 @@ www.iranketab.ir
   }
 
   @Test
+  fun spanishCode() {
+      val testCases = listOf(
+          Pair("Su codigo de verificacion de AAAA es 123456", "123456"),
+          Pair("123456 es el código de verificación para tu cuenta de Sony.", "123456"),
+          Pair("BBB. Clave de firma: 1234. Introduce esta clave de un solo uso (OTP) en el formulario web para firmar (SMS CERTIFICADO)", "1234"),
+          Pair("123 456 es tu código de Instagram. No lo compartas.", "123456"),
+          Pair("PayPal: Tu código de seguridad es 123456. No lo compartas con nadie.", "123456"),
+          Pair("Se ha generado el siguiente codigo de un solo uso: 12345678", "12345678"),
+          Pair("123456 es tu contraseña temporal de Amazon. No la compartas con nadie.", "123456")
+      )
+
+      for ((msg, expectedCode) in testCases) {
+          assertEquals(false, CodeIgnore.shouldIgnore(msg))
+          assertEquals(expectedCode, CodeExtractor.getCode(msg))
+      }
+  }
+
+  @Test
   fun shouldNotExtractAnythingFromWordsContainingOTP() {
     val msg = "123456 is your foOTPath."
     val msg2 = "your foOTPath is 123456."


### PR DESCRIPTION
Hi!

I added some sensitiveWords to support Spanish. I bundled a bunch of real examples into one test. Maybe I jumped the gun by putting all the cases in one test to cut down on noise; let me know if you'd rather have them in individual test functions.

Thanks for the project!