### PR TITLE
Add A-Trust / Handy-Signatur - Fixes #21

### DIFF
--- a/app/src/main/java/io/github/jd1378/otphelper/utils/CodeExtractor.kt
+++ b/app/src/main/java/io/github/jd1378/otphelper/utils/CodeExtractor.kt
@@ -19,6 +19,8 @@ class CodeExtractor {
             "קוד",
             "\\bKodu\\b",
             "\\bKodunuz\\b",
+            "\\bTAN\\b",
+            "\\bmTAN\\b",
         )
 
     private val ignoredWords = listOf("مقدار", "مبلغ", "amount", "برای", "-ارز")
@@ -29,7 +31,7 @@ class CodeExtractor {
                 ignoredWords.joinToString(
                     "|"
                 )
-            })(?<code>[\d\u0660-\u0669\u06F0-\u06F9a-zA-Z]{4,}|)\1(?:[.\s][\n\t]|[.,，]|${'$'})"""
+            })(?<code>[\d\u0660-\u0669\u06F0-\u06F9a-zA-Z]{4,}|( [\d\u0660-\u0669\u06F0-\u06F9a-zA-Z0-9]){4,}|)\1(?:[.\s][\n\t]|[.,，]|${'$'})"""
             .toRegex(
                 setOf(
                     RegexOption.IGNORE_CASE,

--- a/app/src/test/java/io/github/jd1378/otphelper/CodeDetectionUnitTest.kt
+++ b/app/src/test/java/io/github/jd1378/otphelper/CodeDetectionUnitTest.kt
@@ -313,4 +313,18 @@ www.iranketab.ir
     assertEquals(false, CodeIgnore.shouldIgnore(msg4))
     assertEquals("1234", CodeExtractor.getCode(msg4))
   }
+
+  @Test
+  fun atrustHandySignaturCode() {
+    val msg = """Handy-Signatur für
+ eid.oesterreich.gv.at
+Vergleichswert
+ v 7 n M Z S S H 6 l
+TAN
+ 4 u 8 k u f
+Bitte überprüfen Sie alle Werte!
+(5 Min. gültig)"""
+    assertEquals(false, CodeIgnore.shouldIgnore(msg))
+    assertEquals("4u8kuf", CodeExtractor.getCode(msg))
+  }
 }


### PR DESCRIPTION
Example message:

```
Handy-Signatur für
 eid.oesterreich.gv.at
Vergleichswert
 v 7 n M Z S S H 6 l
TAN
 4 u 8 k u f
Bitte überprüfen Sie alle Werte!
(5 Min. gültig)
```

This adds the following regex alternative for code in the generalCodeMatcher

|( [\d\u0660-\u0669\u06F0-\u06F9a-zA-Z0-9]){4,}

This matches values that look like "[space][character]"

It specifically matches one space then exactly one character to avoid including regular text into the parsed output