### PR TITLE
Fix A-Trust: Codes starting with letter

### DIFF
--- a/app/src/main/java/io/github/jd1378/otphelper/utils/CodeExtractor.kt
+++ b/app/src/main/java/io/github/jd1378/otphelper/utils/CodeExtractor.kt
@@ -25,7 +25,7 @@ class CodeExtractor {
 
     private val ignoredWords = listOf("مقدار", "مبلغ", "amount", "برای", "-ارز")
     private val generalCodeMatcher =
-        """(?:${sensitiveWords.joinToString("|")})(?:\s*(?!${
+        """(?:${sensitiveWords.joinToString("|")})(?:\s*(?![a-zA-Z0-9] [a-zA-Z0-9] [a-zA-Z0-9] [a-zA-Z0-9] )(?!${
                 ignoredWords.joinToString("|")
             })[^\s:.'"\d\u0660-\u0669\u06F0-\u06F9])*[:.]?\s*(["']?)(?!${
                 ignoredWords.joinToString(

--- a/app/src/test/java/io/github/jd1378/otphelper/CodeDetectionUnitTest.kt
+++ b/app/src/test/java/io/github/jd1378/otphelper/CodeDetectionUnitTest.kt
@@ -321,10 +321,10 @@ www.iranketab.ir
 Vergleichswert
  v 7 n M Z S S H 6 l
 TAN
- 4 u 8 k u f
+ a u 8 k u f
 Bitte überprüfen Sie alle Werte!
 (5 Min. gültig)"""
     assertEquals(false, CodeIgnore.shouldIgnore(msg))
-    assertEquals("4u8kuf", CodeExtractor.getCode(msg))
+    assertEquals("au8kuf", CodeExtractor.getCode(msg))
   }
 }


### PR DESCRIPTION
Codes starting with letter were broken

A negative lookahead for something that looks like a space-seperated otp  code starting with a letter was added