### PR TITLE
fix: detect 4-char alphanumeric OTP codes (ING bank format)

### DIFF
--- a/app/src/main/java/io/github/jd1378/otphelper/utils/CodeExtractor.kt
+++ b/app/src/main/java/io/github/jd1378/otphelper/utils/CodeExtractor.kt
@@ -143,6 +143,32 @@ class CodeExtractor // this comment is to separate parts
       """(${cleanupPhrases.joinToString("|")})"""
           .toRegex(setOf(RegexOption.IGNORE_CASE, RegexOption.MULTILINE))
 
+  // A token shaped like an OTP code: a 4+ char alphanumeric run containing at
+  // least one digit, or a 4+ char all-uppercase run (e.g. GW7C, 4KAM, QGFDAE).
+  private val codeShape =
+      """(?:(?=[\d\u0660-\u0669\u06F0-\u06F9a-zA-Z\-]*[\d\u0660-\u0669\u06F0-\u06F9])[\d\u0660-\u0669\u06F0-\u06F9a-zA-Z\-]{4,}|[A-Z][A-Z\-]{3,})"""
+
+  // The code shape eligible to trigger the direct cleanup below. It is limited
+  // to digit-bearing tokens on purpose: a pure all-uppercase token (e.g. GW7C
+  // is fine, but DUSG) is indistinguishable from ordinary emphasized prose such
+  // as "code WILL arrive shortly", so accepting it here would auto-detect
+  // non-OTP words. Pure all-letter codes remain best-effort via the existing
+  // generalCodeMatcher and are intentionally not boosted by this cleanup.
+  private val directCodeShape =
+      """(?=[\d\u0660-\u0669\u06F0-\u06F9a-zA-Z\-]*[\d\u0660-\u0669\u06F0-\u06F9])[\d\u0660-\u0669\u06F0-\u06F9a-zA-Z\-]{4,}"""
+
+  // Normalizes a "<phrase> <CODE> <trailing prose>" shape (e.g. ING bank's
+  // "codigo GW7C para confirmar...") into "<phrase>: <CODE>" so the trailing
+  // text cannot be greedily consumed by generalCodeMatcher. The negative
+  // lookahead leaves the message untouched when a later sensitive phrase is
+  // itself followed by another code-shaped token, so a genuine OTP appearing
+  // later in the line still wins over a contextual token captured here.
+  private val directCodeCleanupRegex =
+      """((?i:${sensitivePhrases.joinToString("|")}))\s*($directCodeShape)(?=\s+\p{L})(?![^\r\n]*(?i:${
+        sensitivePhrases.joinToString("|")
+      })[^\r\n]*?$codeShape)[^\r\n]*"""
+          .toRegex(setOf(RegexOption.MULTILINE))
+
   // doCleanup is added for convenience in unit testing
   fun getCode(str: String, doCleanup: Boolean = true): String? {
     if (sensitivePhrases.isEmpty()) return null
@@ -231,6 +257,12 @@ class CodeExtractor // this comment is to separate parts
 
   fun cleanup(str: String): String {
     if (cleanupPhrases.isEmpty()) return str
-    return str.replace(cleanupPhrasesRegex, "")
+    var result = str.replace(cleanupPhrasesRegex, "")
+    // Only isolate the code from trailing prose when there is a sensitive
+    // phrase to anchor on; with an empty list the regex would match without one.
+    if (sensitivePhrases.isNotEmpty()) {
+      result = result.replace(directCodeCleanupRegex, "${'$'}1: ${'$'}2")
+    }
+    return result
   }
 }

--- a/app/src/test/resources/code_detection_tests.yaml
+++ b/app/src/test/resources/code_detection_tests.yaml
@@ -323,6 +323,26 @@
   shouldIgnore: false
   expectedCode: "123456"
 
+# ING bank (Spain) 4-char alphanumeric codes, see issue #220.
+# Codes that contain a digit are reliably isolated from the trailing prose.
+# A pure all-letter code (DUSG) is indistinguishable from an emphasized prose
+# word, so it stays best-effort (not detected) to avoid false positives.
+
+- name: ingCodeTF33
+  message: 'ING: Introduce el codigo TF33 para confirmar tu operacion. Si no has sido tu quien ha realizado la operacion llamanos al 912066666'
+  shouldIgnore: false
+  expectedCode: TF33
+
+- name: ingCode4KAM
+  message: 'ING: Introduce el codigo 4KAM para acceder a ING de forma segura. Si no lo has solicitado, te recomendamos cambiar tu clave cuanto antes en tu Area personal.'
+  shouldIgnore: false
+  expectedCode: 4KAM
+
+- name: ingCodeGW7C
+  message: 'ING: Introduce el codigo GW7C para confirmar tu operacion. Si no has sido tu quien ha realizado la operacion llamanos al 912066666'
+  shouldIgnore: false
+  expectedCode: GW7C
+
 # ── French ─────────────────────────────────────────────────────────────────────
 
 - name: frenchCode


### PR DESCRIPTION
## Summary

Improves detection of short alphanumeric OTP codes that are followed by trailing message text, such as the Spanish ING bank messages reported in #220:

```
ING: Introduce el codigo GW7C para confirmar tu operacion. Si no has sido tu ...
```

Before this change `generalCodeMatcher` greedily consumed the code token (`GW7C`) together with the rest of the sentence, and its empty fallback alternative then matched, so `getCode()` returned `null`. Codes that happen to end in digits (e.g. `TF33`) worked only by accident, because the trailing digits created a boundary the all-letter scan could not cross.

Rather than reworking the load-bearing `generalCodeMatcher`, this adds a small normalization step in `cleanup()` (the approach you suggested on the issue): when a sensitive phrase is directly followed by a code-shaped token and then trailing prose, the trailing text is dropped so the code sits at the end of the line where the existing matcher reliably captures it. `cleanup()` already runs before detection, so this slots into the existing pipeline.

## Why this matters

Reference #220. The reporter (danielaixer) supplied real ING messages where `GW7C`, `DUSG`, `4KAM` were missed while `TF33` worked. You noted alphanumeric detection is best-effort and suggested a cleanup regex to strip the irrelevant trailing text before detection runs; that is exactly what this does.

To avoid false positives, the cleanup is deliberately conservative:

- It only triggers on **digit-bearing** code tokens (e.g. `GW7C`, `4KAM`, `TF33`). A pure all-letter token like `DUSG` is shape-indistinguishable from an emphasized prose word (`code WILL arrive shortly`), so it is intentionally left to the existing best-effort matcher rather than risk auto-detecting ordinary words.
- The trailing text is left untouched when a later sensitive phrase is itself followed by another code-shaped token, so a genuine OTP appearing later in the same line still wins over a contextual token (e.g. `Your OTP 3DSecure ... code is 123456` still resolves to `123456`).
- When the sensitive-phrase list is empty (user cleared it), the cleanup is skipped entirely so unrelated text is never rewritten.

Trade-off worth your call: because the only anchor is the sensitive phrase, a non-OTP reference like `tracking code A1B2 shipped` is now treated the same as an OTP. This is inherent to anchoring on `code` and matches the best-effort nature you described; happy to tighten the anchor (e.g. exclude error/tracking/case contexts) if you'd prefer.

## Testing

The repo's data-driven harness (`CodeDetectionUnitTest` reading `code_detection_tests.yaml`) drove the change. Added the three reported digit-bearing ING messages (`ingCodeTF33`, `ingCode4KAM`, `ingCodeGW7C`) and tuned the cleanup until they pass with no regression to the existing suite.

```
./gradlew :app:testNormalDebugUnitTest --tests "*CodeDetectionUnitTest*"
# BUILD SUCCESSFUL — 202 tests, 0 failures
```

Also verified manually that ordinary uppercase prose after a phrase (`Your verification code WILL arrive shortly`, `Use promo code SALE for discounts`) still returns `null`, and that existing all-caps codes at end of message (`code: QGFDAE`) are unaffected.

Fixes #220
